### PR TITLE
Add basic Jekyll configuration and pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+vendor/

--- a/404.html
+++ b/404.html
@@ -1,0 +1,7 @@
+---
+permalink: /404.html
+layout: default
+---
+
+<h1>404</h1>
+<p>Page not found</p>

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "jekyll-theme-minimal", "~> 0.1.1"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # KoreanTuna.github.io
+
+This repository contains a minimal [Jekyll](https://jekyllrb.com/) site for testing GitHub Pages hosting.
+
+## Local Development
+
+1. Install dependencies:
+
+   ```bash
+   bundle install
+   ```
+
+2. Build and serve locally:
+
+   ```bash
+   bundle exec jekyll serve
+   ```
+
+   Then open <http://localhost:4000> in your browser.

--- a/index.md
+++ b/index.md
@@ -1,0 +1,7 @@
+---
+title: Welcome
+---
+
+# Welcome
+
+This site is for hosting tests.


### PR DESCRIPTION
## Summary
- add Jekyll configuration and minimal starter pages for GitHub Pages
- document local development steps with bundler and jekyll

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6de667b883258e96eeb61c504578