### PR TITLE
Add assetlinks.json for Android app links

### DIFF
--- a/.well-known/assetlinks.json
+++ b/.well-known/assetlinks.json
@@ -1,0 +1,11 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.example.payment_demo",
+      "sha256_cert_fingerprints":
+      ["3E:26:C6:89:6D:61:BC:30:0E:D7:0D:23:39:A5:08:21:92:75:F6:45:B4:BD:05:53:3B:17:0B:4E:00:36:2F:B7"]
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add `.well-known/assetlinks.json` for com.example.payment_demo app

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68ac7241f1c8832580b3be81237708a7